### PR TITLE
[fix] Daggy and DaggyCore always require Qt6 Network

### DIFF
--- a/src/Daggy/CMakeLists.txt
+++ b/src/Daggy/CMakeLists.txt
@@ -2,7 +2,7 @@ set(TARGET daggy)
 
 option(PCAPNG_SUPPORT "pcap to pcapng convertor" OFF)
 
-find_package(Qt6 COMPONENTS Core REQUIRED)
+find_package(Qt6 COMPONENTS Core Network CONFIG REQUIRED)
 
 add_executable(${TARGET})
 include(rpath_bin)
@@ -15,7 +15,7 @@ target_sources(${TARGET}
         CConsoleDaggy.cpp
 )
 
-target_link_libraries(${TARGET} PRIVATE DaggyCore)
+target_link_libraries(${TARGET} PRIVATE DaggyCore Qt6::Core Qt6::Network)
 
 if (PCAPNG_SUPPORT)
     add_compile_definitions(PCAPNG_SUPPORT)

--- a/src/DaggyCore/CMakeLists.txt
+++ b/src/DaggyCore/CMakeLists.txt
@@ -48,7 +48,7 @@ target_sources(${TARGET}
         aggregators/CConsole.hpp
 )
 
-target_link_libraries(${TARGET} PUBLIC Qt6::Core)
+target_link_libraries(${TARGET} PUBLIC Qt6::Core Qt6::Network CONFIG REQUIRED)
 
 if (SSH2_SUPPORT)
     if(CONAN_BUILD)
@@ -57,7 +57,6 @@ if (SSH2_SUPPORT)
     else()
         target_link_libraries(${TARGET} PUBLIC ssh2 crypto)
     endif()
-    target_link_libraries(${TARGET} PUBLIC Qt6::Network)
 
     target_sources(${TARGET}
         PRIVATE

--- a/src/DaggyCore/CMakeLists.txt
+++ b/src/DaggyCore/CMakeLists.txt
@@ -48,7 +48,7 @@ target_sources(${TARGET}
         aggregators/CConsole.hpp
 )
 
-target_link_libraries(${TARGET} PUBLIC Qt6::Core Qt6::Network CONFIG REQUIRED)
+target_link_libraries(${TARGET} PUBLIC Qt6::Core Qt6::Network)
 
 if (SSH2_SUPPORT)
     if(CONAN_BUILD)


### PR DESCRIPTION
Hello!

When building the project with the CMake option `CONSOLE=ON`, it fails to build due the following error:

```
[2/24] /usr/bin/c++ -DCONAN_BUILD -DDaggyCore_EXPORTS -DQT_CORE_LIB -DQT_NO_DEBUG -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/DaggyCore_autogen/include -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/exports -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/src/src -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/src/src/DaggyCore/.. -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include/QtCore -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/mkspecs/linux-g++ -m64 -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -Winvalid-pch -x c++-header -include /home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx -MD -MT DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch -MF DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch.d -o DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch -c /home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.cxx
FAILED: [code=1] DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch 
/usr/bin/c++ -DCONAN_BUILD -DDaggyCore_EXPORTS -DQT_CORE_LIB -DQT_NO_DEBUG -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/DaggyCore_autogen/include -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/exports -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/src/src -I/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/src/src/DaggyCore/.. -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include/QtCore -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/mkspecs/linux-g++ -m64 -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -Winvalid-pch -x c++-header -include /home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx -MD -MT DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch -MF DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch.d -o DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.gch -c /home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx.cxx
In file included from /home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx:5,
                 from <command-line>:
/home/uilian/.conan2/p/b/daggy1d7b04eeacd13/b/src/src/DaggyCore/Precompiled.hpp:30:10: fatal error: QHostAddress: No such file or directory
   30 | #include <QHostAddress>
      |          ^~~~~~~~~~~~~~
```

You can see the full build log: [daggy-2.2.3-linux-gcc11-shared.log](https://github.com/user-attachments/files/22941874/daggy-2.2.3-linux-gcc11-shared.log)

It occurs because both DaggyCore and Daggy (console app) include the header file `Precompiled.hpp`, which needs `QHostAddress`. As the `QHostAddress` is part of the Qt Network module and both Daggy projects always use `Precompiled.hpp`, the `Qt6::Network` CMake target should always be listed as required.

This PR adds Qt6 Network as a required module, and lists its CMake target to be used by both Daggy (console app) and DaggyCode (library).

Regards. 
