### PR TITLE
[fix] Add missing noexcept for yaml method implementation

### DIFF
--- a/src/DaggyCore/Sources.cpp
+++ b/src/DaggyCore/Sources.cpp
@@ -408,7 +408,7 @@ catch (const std::exception& exception) {
 }
 
 #else
-std::optional<daggy::Sources> daggy::sources::convertors::yaml(const QString& data, QString& error)
+std::optional<daggy::Sources> daggy::sources::convertors::yaml(const QString& data, QString& error) noexcept
 {
     error = "yaml not supported";
     return {};


### PR DESCRIPTION
Hello!

When building Daggy (console) without YAML support, the following error occurs:

```
FAILED: [code=1] DaggyCore/CMakeFiles/DaggyCore.dir/Sources.cpp.o 
/usr/bin/c++ -DCONAN_BUILD -DDaggyCore_EXPORTS -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -I/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/build/Release/DaggyCore/DaggyCore_autogen/include -I/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/build/Release/exports -I/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src -I/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src/DaggyCore/.. -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include/QtCore -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/mkspecs/linux-g++ -isystem /home/uilian/.conan2/p/b/qtf9d9cecdf8905/p/include/QtNetwork -m64 -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -Winvalid-pch -include /home/uilian/.conan2/p/b/daggy70bebc8b247de/b/build/Release/DaggyCore/CMakeFiles/DaggyCore.dir/cmake_pch.hxx -MD -MT DaggyCore/CMakeFiles/DaggyCore.dir/Sources.cpp.o -MF DaggyCore/CMakeFiles/DaggyCore.dir/Sources.cpp.o.d -o DaggyCore/CMakeFiles/DaggyCore.dir/Sources.cpp.o -c /home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src/DaggyCore/Sources.cpp
/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src/DaggyCore/Sources.cpp:411:31: error: declaration of ‘std::optional<QMap<QString, daggy::sources::Properties> > daggy::sources::convertors::yaml(const QString&, QString&)’ has a different exception specifier
  411 | std::optional<daggy::Sources> daggy::sources::convertors::yaml(const QString& data, QString& error)
      |                               ^~~~~
In file included from /home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src/DaggyCore/Sources.cpp:25:
/home/uilian/.conan2/p/b/daggy70bebc8b247de/b/src/src/DaggyCore/Sources.hpp:93:41: note: from previous declaration ‘std::optional<QMap<QString, daggy::sources::Properties> > daggy::sources::convertors::yaml(const QString&, QString&) noexcept’
   93 | DAGGYCORE_EXPORT std::optional<Sources> yaml(const QString& data, QString& error) noexcept;
```

You can check my full build log here: [daggy-2.2.3-linux-gcc11-shared.log](https://github.com/user-attachments/files/22942036/daggy-2.2.3-linux-gcc11-shared.log)

That error occurred because the header `Sources.hpp` declared `noexcept` for `yaml()`, but the same is not true for its implementation when yaml is not supported.

* Header Sources: https://github.com/synacker/daggy/blob/9d6b7412d4007af187c20e8cf89b33b7da062972/src/DaggyCore/Sources.hpp#L93
* Implementation with YAML: https://github.com/synacker/daggy/blob/9d6b7412d4007af187c20e8cf89b33b7da062972/src/DaggyCore/Sources.cpp#L391
* Implementation without YAML: https://github.com/synacker/daggy/blob/9d6b7412d4007af187c20e8cf89b33b7da062972/src/DaggyCore/Sources.cpp#L411


Regards. 

